### PR TITLE
std::is_pod<> was deprecated in C++20.

### DIFF
--- a/re2/pod_array.h
+++ b/re2/pod_array.h
@@ -13,7 +13,7 @@ namespace re2 {
 template <typename T>
 class PODArray {
  public:
-  static_assert(std::is_pod<T>::value,
+  static_assert(std::is_trivial<T>::value && std::is_standard_layout<T>::value,
                 "T must be POD");
 
   PODArray()


### PR DESCRIPTION
Change-Id: I52b1b96ee49c41db201a71a58a2bb5a51d7c0e10
Reviewed-on: https://code-review.googlesource.com/c/re2/+/49590
Reviewed-by: Paul Wankadia <junyer@google.com>